### PR TITLE
Update question 350

### DIFF
--- a/questions/350/explanation.md
+++ b/questions/350/explanation.md
@@ -1,5 +1,5 @@
 First, a `Q` instance is default-constructed in `takeQfunc()`, printing `D`.
-Then `q.func()` is caled, which prints `0`.
+Then `q.func()` is called, which prints `0`.
 Next, we call `qfunc(q)`. Although the lambda's parameter list specifies that it takes an rvalue reference `Q&&`, the `q` is actually first passed to `qfunc`, which takes a plain `Q` by value. A copy is made, printing `C`. Then, the `std::function::operator()` `std::forward`s its argument to the lambda, and the lambda's rvalue reference can bind to the newly copied `q`. Since the reference binds to this copy rather than the original, `q.change()` doesn't change the original `q`.
 Then, `q.func()` is called again, which prints `0`.
 
@@ -16,15 +16,15 @@ class function<R(ArgTypes...)> {
 }
 ```
 
- `takeFunc` explicitly specializes what kind of `std::function` it accepts (rather than e.g. being a function template that deduces it from the lambda we pass to it). It explicitly sets the return type `R` to `void`, and the template parameter pack `ArgTypes...` to `Q`. That means that the signature of `operator()` is `void operator()(Q) const`; taking `Q` by value.
+`takeFunc` explicitly specializes what kind of `std::function` it accepts (rather than e.g. being a function template that deduces it from the lambda we pass to it). It explicitly sets the return type `R` to `void`, and the template parameter pack `ArgTypes...` to `Q`. That means that the signature of `operator()` is `void operator()(Q) const`; taking `Q` by value.
  
- §[func.wrap.func.inv] continues:
+§[func.wrap.func.inv] continues:
  
 > `R operator()(ArgTypes... args) const;`
-> Returns: `INVOKE<R>(f, std​::​forward<ArgTypes>(args)...)` ([func.require]), where `f` is the target object of `*this`.
+> Returns: `INVOKE<R>(f, std​::​forward<ArgTypes>(args)...)` ([func.require]), where `f` is the target object ([func.def]) of `*this`.
 
-If we substitude the types in `INVOKE<R>(f), std​::​forward<ArgTypes>(args)...)`, we get  `INVOKE<void>(f), std​::​forward<Q>(q))`, which just means `f(std::forward<Q>(q))`.
+If we substitute the types in `INVOKE<R>(f, std​::​forward<ArgTypes>(args)...)`, we get `INVOKE<void>(f, std​::​forward<Q>(q))`, which just means `f(std::forward<Q>(q))`.
 
-So when we call `qfunc(q)`, it passes `q` by value to `qfunc`. The `std::function::operator()` then wraps that copy in `std::forward<Q>`, turning it into an rvalue refrence, before passing it to the lambda. The `Q&&` parameter to our lambda can bind directly to this forwarded `q`, no move is necessary.
+So when we call `qfunc(q)`, it passes `q` by value to `qfunc`. The `std::function::operator()` then wraps that copy in `std::forward<Q>`, turning it into an rvalue reference (§[forward]¶3), before passing it to the lambda. The `Q&&` parameter to our lambda can bind directly to this forwarded `q`, no move is necessary.
 
 Then, the lambda calls `q.change()` on this copied `q`, which modifies the `v` member. But this copy of `q` is never used again.

--- a/questions/350/question.cpp
+++ b/questions/350/question.cpp
@@ -1,33 +1,24 @@
-#include<iostream>
-#include<functional>
-class Q{
-    int v=0;
-    public:
-        Q(Q&&){
-            std::cout << "M";
-        }
-        Q(const Q&){
-            std::cout << "C";
-        }
-        Q(){
-            std::cout << "D";
-        }
-        void change(){
-            ++v;
-        }
-        void func(){
-            std::cout << v;
-        }
+#include <functional>
+#include <iostream>
+
+struct Q {
+    int v = 0;
+
+    Q() { std::cout << "D"; }
+    Q(const Q&) { std::cout << "C"; }
+    Q(Q&&) { std::cout << "M"; }
+
+    void change() { ++v; }
+    void func() { std::cout << v; }
 };
-void takeQfunc(std::function<void(Q)> qfunc){
+
+void takeQfunc(std::function<void(Q)> qfunc) {
     Q q;
     q.func();
     qfunc(q);
     q.func();
 }
-int main(){
-    takeQfunc([](Q&& q){
-        q.change();
-    });
-    return 0;
+
+int main() {
+    takeQfunc([](Q&& q) { q.change(); });
 }


### PR DESCRIPTION
* [Update question 350](https://github.com/knatten/cppquiz23/commit/5b3e99767ea401b6420c2195ca8c8b5b37c33bef)
This commit also adds an additional reference that explains the rvalue reference cast.
Fixes https://github.com/knatten/cppquiz23/issues/170.
* [Reformat code of question 350](https://github.com/knatten/cppquiz23/commit/5614da36053afc46a0fbf41ecd5047106e1724dd)
I used the "Format document" button in Compiler Explorer and removed unnecessary lines. I think it's easier to read now, but we can revert this commit if you don't want to touch the code.