### PR TITLE
Update question 335

### DIFF
--- a/questions/335/explanation.md
+++ b/questions/335/explanation.md
@@ -2,8 +2,8 @@
 > The macro NULL is an implementation-defined null pointer constant.
 
 §[conv.ptr]¶1:
-> A null pointer constant is an integer literal with value zero or a prvalue of type std​::​nullptr_­t.
+> A null pointer constant is an integer literal ([lex.icon]) with value zero or a prvalue of type std​::​nullptr_t.
 
-In most implementations, `NULL` will be an integer literal and the program will not compile due to ambiguous call `f(NULL)`. However the C++ standard allows `NULL` to be a prvalue of `std::nullptr_t` in which case the program would output `122`.
+In most implementations, `NULL` will be an integer literal and the program will not compile due to ambiguous call `f(NULL)`. However, the C++ standard allows `NULL` to be a prvalue of `std::nullptr_t` in which case the program would output `122`.
 
 Here is [an example](https://www.godbolt.org/z/87r46WP6x) where GCC and Clang use `long` for `NULL`, and MSVC uses `int`.


### PR DESCRIPTION
There was a soft hyphen in std::nullptr_t for some reason.
See https://unicodeplus.com/U+00AD.

Fixes https://github.com/knatten/cppquiz23/issues/77.