### PR TITLE
Update question 281 and fix the commenting style

### DIFF
--- a/questions/106/explanation.md
+++ b/questions/106/explanation.md
@@ -1,6 +1,6 @@
 According to §[dcl.link]¶7 in the standard : A declaration directly contained in a linkage-specification is treated as if it contains the extern specifier for the purpose of determining the linkage of the declared name and whether it is a definition.
-    extern "C" int x; //is just a declaration
-    extern "C" { int y; } //is a definition
+    extern "C" int x; // is just a declaration
+    extern "C" { int y; } // is a definition
 
 And according to  §[basic.def.odr]¶4: "Every program shall contain exactly one definition of every non-inline function or variable that is odr-used in that program outside of a discarded statement; no diagnostic required."
 

--- a/questions/140/question.cpp
+++ b/questions/140/question.cpp
@@ -19,7 +19,7 @@ size_t get_size_3(int (&arr)[10])
 int main()
 {
   int array[10];
-  //Assume sizeof(int*) != sizeof(int[10])
+  // Assume sizeof(int*) != sizeof(int[10])
   cout << (sizeof(array) == get_size_1(array));
   cout << (sizeof(array) == get_size_2(array));
   cout << (sizeof(array) == get_size_3(array));

--- a/questions/281/explanation.md
+++ b/questions/281/explanation.md
@@ -1,24 +1,25 @@
 We're initializing `c2` from an rvalue, so it would be preferable to have a move constructor available. But since we declare a copy constructor, we do not get an implicit move constructor:
 
-[class.copy.ctor]§x15.8.1¶8:
-> If the definition of a class X does not explicitly declare a move constructor, a non-explicit one will be implicitly declared as defaulted if and only if
-> (8.1) — X does not have a user-declared copy constructor,
-> — (...)
+§[class.copy.ctor]¶8.1:
 
-So we don't have a move constructor. But can we still initialize `c2`? 
+> If the definition of a class `X` does not explicitly declare a move constructor, a non-explicit one will be implicitly declared as defaulted if and only if
+>
+> — `X` does not have a user-declared copy constructor,
+
+So we don't have a move constructor. But can we still initialize `c2`?
 
 When overload resolution looks for a constructor to use, the candidate functions are all the constructors of the class. If we had both a copy and a move constructor, the move constructor would be picked as the best viable function.
 
 However, in this case we only have a copy constructor. Is it too a viable function? For it to be viable, we need to be able to bind `const C&` to the xvalue `std::move(c)`.
 
-§[dcl.init.ref] has the details for initializing references. It first discusses binding to lvalues, which is not the case here, then it gets to  §[dcl.init.ref]¶5.2:
+§[dcl.init.ref] has the details for initializing references. It first discusses binding to lvalues, which is not the case here, then it gets to §[dcl.init.ref]¶5.2:
 
-> Otherwise, the reference shall be an lvalue reference to a non-volatile const type (i.e., cv1 shall be const), or the reference shall be an rvalue reference.
+> — Otherwise, if the reference is an lvalue reference to a type that is not const-qualified or is volatile-qualified, the program is ill-formed.
 
-Our reference `const C&` is indeed an lvalue reference to non-volatile const. It continues:
+Our reference `const C&` is an lvalue reference to non-volatile const, so this clause doesn't apply here either. It continues:
 
-> If the initializer expression is an rvalue(...) then the value of the initializer expression (...) is called the converted initializer. (...) In any case, the reference is bound to the resulting glvalue (or to an appropriate base class subobject).
+> — Otherwise, if the initializer expression (...) is an rvalue (...) then the initializer expression (...) is called the converted initializer. (...) In any case, the reference binds to the resulting glvalue (or to an appropriate base class subobject).
 
-We won't explain value categories here (see [lvalues, rvalues, glvalues, prvalues, xvalues, help!](https://blog.knatten.org/2018/03/09/lvalues-rvalues-glvalues-prvalues-xvalues-help/) for an introduction), but the xvalue `std::move(c)` is _both_ an rvalue and a glvalue. So the clause "if [it] is an rvalue" above applies, as does "the resulting glvalue".
+We won't explain value categories here (see [lvalues, rvalues, glvalues, prvalues, xvalues, help!](https://blog.knatten.org/2018/03/09/lvalues-rvalues-glvalues-prvalues-xvalues-help/) for an introduction), but the xvalue `std::move(c)` is *both* an rvalue and a glvalue. So the clause "if [it] is an rvalue" above applies, as does "the resulting glvalue".
 
 So the `const C&` in the copy constructor is bound to the glvalue `std::move(c)`. The copy constructor is indeed a viable function, and is used to construct `c2`.

--- a/questions/281/hint.md
+++ b/questions/281/hint.md
@@ -1,1 +1,1 @@
-A move constructor will not be implicitly declared if the user declares a copy constructor.  But do we need a move constructor to initialize `c2`?
+A move constructor will not be implicitly declared if the user declares a copy constructor. But do we need a move constructor to initialize `c2`?

--- a/questions/281/question.cpp
+++ b/questions/281/question.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <utility>
 
 class C
 {

--- a/questions/281/question.cpp
+++ b/questions/281/question.cpp
@@ -4,7 +4,7 @@ class C
 {
 public:
     C(){}
-    C(const C&){} //User-declared, disables move constructor
+    C(const C&){} // User-declared, disables move constructor
 };
 
 int main()

--- a/questions/326/question.cpp
+++ b/questions/326/question.cpp
@@ -2,7 +2,7 @@
 
 struct S;
 
-S foo(S s); //S has only been forward declared at this point
+S foo(S s); // S has only been forward declared at this point
 
 struct S{};
 


### PR DESCRIPTION
* [Add a single space for comments](https://github.com/knatten/cppquiz23/commit/8d3646d3499d75c6e54fb62f0e1ef35542a79404)
This commit makes the commenting style consistent across the questions.
* [Update question 281](https://github.com/knatten/cppquiz23/commit/9388a5fd7b5a7023b21120fa65d8c9014ee295ad)
Fixes https://github.com/knatten/cppquiz23/issues/151.